### PR TITLE
fix(deck-proxy): repositories up one level

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ spinnaker:
         Aws.LambdaDeploymentPlugin:
           enabled: true
           version: <<VERSION NUMBER>>
-      repositories:
-        awsLambdaDeploymentPluginRepo:
-          url: https://raw.githubusercontent.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/master/plugins.json
+    repositories:
+      awsLambdaDeploymentPluginRepo:
+        url: https://raw.githubusercontent.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/master/plugins.json
 ```
 3. Execute `hal deploy apply` to deploy the changes.
 4. You should now be able to see 3 new stages provided by this plugin in the Deck UI when adding a new stage to your pipeline.


### PR DESCRIPTION
Move `repositories` up one level (to the same level as deck-proxy)