### PR TITLE
Fix WaitForCachePublish when publish is false

### DIFF
--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/upsert/LambdaWaitForCachePublishTask.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/upsert/LambdaWaitForCachePublishTask.java
@@ -64,7 +64,8 @@ public class LambdaWaitForCachePublishTask implements LambdaStageBaseTask {
                 }
                 utils.await(10000);
             }
+            return this.formErrorTaskResult(stage, "Failed to update cache after PublishVersionTask");
         }
-        return this.formErrorTaskResult(stage, "Failed to update cache after PublishVersionTask");
+        return taskComplete(stage);
     }
 }


### PR DESCRIPTION
Found a small bug in my previous [PR](https://github.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/pull/49), when publish is set to false the `LambdaWaitForCachePublishTask` fails.

