### PR TITLE
fix(verify): Lambda Pending state fix

### DIFF
--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/LambdaDeploymentStage.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/LambdaDeploymentStage.java
@@ -46,6 +46,7 @@ public class LambdaDeploymentStage implements StageDefinitionBuilder {
         builder.withTask("lambdaCacheRefreshTask", LambdaCacheRefreshTask.class);
         builder.withTask("lambdaCreateTask", LambdaCreateTask.class);
         builder.withTask("lambdaUpdateCodeTask", LambdaUpdateCodeTask.class);
+        builder.withTask("LambdaWaitToStabilizeTask", LambdaWaitToStabilizeTask.class);
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);
         builder.withTask("lambdaUpdateConfigTask", LambdaUpdateConfigurationTask.class);
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);
@@ -61,7 +62,6 @@ public class LambdaDeploymentStage implements StageDefinitionBuilder {
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);
         builder.withTask("lambdaCacheRefreshTask", LambdaCacheRefreshTask.class);
         builder.withTask("lambdaWaitForCachePublishTask", LambdaWaitForCachePublishTask.class);
-        builder.withTask("LambdaWaitToStabilizeTask", LambdaWaitToStabilizeTask.class);
         builder.withTask("lambdaOutputTask", LambdaOutputTask.class);
     }
 }


### PR DESCRIPTION
A pending state for a lambda function prevents routing traffic
or attaching event sources. The earlier fix with waiting for it
to stablize still applies but needs to be pushed further up in
order for it to happen before we try to attach event sources etc.

fixes #70