### PR TITLE
feat(concurrency): add support for delete provisioned and reserved concurrency

### DIFF
--- a/lambda-deployment-deck/src/deployLambda/components/AwsLambdaFunctionStageForm.tsx
+++ b/lambda-deployment-deck/src/deployLambda/components/AwsLambdaFunctionStageForm.tsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 
 import { Option } from 'react-select';
 
-
 import {
   FormikFormField,
   HelpField,
@@ -27,6 +26,8 @@ import {
   NetworkForm,
   TriggerEventsForm,
 } from '.';
+
+import { NumberConcurrencyInput } from '../../utils/NumberConcurrencyInput';
 
 export function AwsLambdaFunctionStageForm(props: IFormikStageConfigInjectedProps) {
   const { values, errors } = props.formik; 
@@ -112,7 +113,7 @@ export function AwsLambdaFunctionStageForm(props: IFormikStageConfigInjectedProp
         name="reservedConcurrentExecutions"
         label="Reserved Concurrency"
         help={<HelpField content="The total number of current executions of your Lambda function that can be instantiated at any time." />}
-        input={props => <NumberInput {...props} max={3000} />} 
+        input={props => <NumberConcurrencyInput {...props} min={0} max={3000} />}
       />
       <FormikFormField
         name="memorySize" 

--- a/lambda-deployment-deck/src/routeLambda/RouteLambdaFunctionStageForm.tsx
+++ b/lambda-deployment-deck/src/routeLambda/RouteLambdaFunctionStageForm.tsx
@@ -32,6 +32,10 @@ import {
   TriggerEventsForm
 } from './TriggerEventsForm';
 
+import {
+  NumberConcurrencyInput
+} from '../utils/NumberConcurrencyInput';
+
 export function RouteLambdaFunctionStageForm(props: IFormikStageConfigInjectedProps) {
   const { values, errors } = props.formik; 
   const { functions } = props.application;
@@ -135,7 +139,7 @@ export function RouteLambdaFunctionStageForm(props: IFormikStageConfigInjectedPr
         name="provisionedConcurrentExecutions"
         label="Provisioned Concurrency"
         help={<HelpField content="To enable your function to scale without fluctuations in latency, use provisioned concurrency. Provisioned concurrency runs continually and has separate pricing for concurrency and execution duration. Concurrency cannot be provisioned with a weighted deployment strategy." />}
-        input={props => <NumberInput {...props} min={0} max={values.deploymentStrategy === "$WEIGHTED" ? 0 : 3000} />}
+        input={props => <NumberConcurrencyInput {...props} min={0} max={values.deploymentStrategy === "$WEIGHTED" ? 0 : 3000} />}
         required={false}
       />
       

--- a/lambda-deployment-deck/src/utils/MyValidators.ts
+++ b/lambda-deployment-deck/src/utils/MyValidators.ts
@@ -1,0 +1,36 @@
+import { isNumber, isEmpty } from 'lodash';
+
+import type { IValidator } from '@spinnaker/core';
+
+const THIS_FIELD = 'This field';
+
+const minValue = (min: number, message?: string): IValidator => {
+  return function minValue(val: number, label = THIS_FIELD) {
+    if (!isNumber(val)) {
+      return message || `${label} must be a number - Empty or invalid inputs will perform a DELETE`;
+    } else if (val < min) {
+      const minText = min === 0 ? 'cannot be negative' : `cannot be less than ${min}`;
+      return message || `${label} ${minText}`;
+    } else if (val === 0 && label == "Reserved Concurrency") {
+      return message || `Your function will be throttled.`;
+    } else if (val === 0) {
+      return message || `0 Will perform a DELETE - The minimum provisioned concurrency value allowed is 1.`;
+    }
+    return null;
+  };
+};
+
+const maxValue = (max: number, message?: string): IValidator => {
+  return function maxValue(val: number, label = THIS_FIELD) {
+    if (val > max) {
+      const maxText = `cannot be greater than ${max}`;
+      return message || `${label} ${maxText}`;
+    }
+    return null;
+  };
+};
+
+export const Validators = {
+  maxValue,
+  minValue,
+};

--- a/lambda-deployment-deck/src/utils/NumberConcurrencyInput.tsx
+++ b/lambda-deployment-deck/src/utils/NumberConcurrencyInput.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import {
+  IFormInputProps,
+  OmitControlledInputPropsFrom,
+  useInternalValidator,
+  orEmptyString,
+  validationClassName,
+  IValidator,
+  composeValidators,
+} from '@spinnaker/core';
+
+import {
+  Validators
+} from './MyValidators'
+
+interface INumberInputProps extends IFormInputProps, OmitControlledInputPropsFrom<React.InputHTMLAttributes<any>> {
+  inputClassName?: string;
+}
+
+const isNumber = (val: any): val is number => typeof val === 'number';
+
+export function NumberConcurrencyInput(props: INumberInputProps) {
+  const { value, validation, inputClassName, ...otherProps } = props;
+
+  const minMaxValidator: IValidator = (val: any, label?: string) => {
+    const minValidator = isNumber(props.min) ? Validators.minValue(props.min) : undefined;
+    const maxValidator = isNumber(props.max) ? Validators.maxValue(props.max) : undefined;
+    const validator = composeValidators([minValidator, maxValidator]);
+    return validator ? validator(val, label) : null;
+  };
+
+  useInternalValidator(validation, minMaxValidator);
+
+  const className = `NumberInput form-control ${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
+  return <input className={className} type="number" value={orEmptyString(value)} {...otherProps} />;
+}

--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/LambdaCloudOperationOutput.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/LambdaCloudOperationOutput.java
@@ -18,7 +18,6 @@
 package com.amazon.aws.spinnaker.plugin.lambda;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.netflix.spinnaker.orca.api.simplestage.SimpleStageOutput;
 import lombok.Builder;
 import lombok.Data;
 

--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/LambdaDeploymentStage.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/LambdaDeploymentStage.java
@@ -52,6 +52,7 @@ public class LambdaDeploymentStage implements StageDefinitionBuilder {
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);
         builder.withTask("lambdaUpdateConfigTask", LambdaUpdateConfigurationTask.class);
         builder.withTask("lambdaPutConcurrencyTask", LambdaPutConcurrencyTask.class);
+        builder.withTask("lambdaDeleteConcurrencyTask", LambdaDeleteConcurrencyTask.class);
         builder.withTask("lambdaEventConfigurationTask", LambdaUpdateEventConfigurationTask.class);
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);
         builder.withTask("lambdaUpdateAliasesTask", LambdaUpdateAliasesTask.class);

--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/LambdaSpringLoaderPlugin.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/LambdaSpringLoaderPlugin.java
@@ -70,6 +70,7 @@ public class LambdaSpringLoaderPlugin extends SpringLoaderPlugin {
                 Pair.of("lambdaWaitForCachePublishTask", LambdaWaitForCachePublishTask.class),
                 Pair.of("lambdaOutputTask", LambdaOutputTask.class),
                 Pair.of("lambdaPutConcurrencyTask", LambdaPutConcurrencyTask.class),
+                Pair.of("lambdaDeleteConcurrencyTask", LambdaDeleteConcurrencyTask.class),
                 Pair.of("lambdaTrafficUpdateVerificationTask", LambdaTrafficUpdateVerificationTask.class),
                 Pair.of("lambdaUpdateEventConfigurationTask", LambdaUpdateEventConfigurationTask.class),
                 Pair.of("trafficUpdateStrategyInjector", TrafficUpdateStrategyInjector.class),

--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/traffic/LambdaTrafficRoutingStage.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/traffic/LambdaTrafficRoutingStage.java
@@ -18,6 +18,7 @@
 package com.amazon.aws.spinnaker.plugin.lambda.traffic;
 
 import com.amazon.aws.spinnaker.plugin.lambda.eventconfig.LambdaUpdateEventConfigurationTask;
+import com.amazon.aws.spinnaker.plugin.lambda.upsert.LambdaDeleteConcurrencyTask;
 import com.amazon.aws.spinnaker.plugin.lambda.upsert.LambdaPutConcurrencyTask;
 import com.amazon.aws.spinnaker.plugin.lambda.verify.LambdaVerificationTask;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
@@ -44,6 +45,7 @@ public class LambdaTrafficRoutingStage implements StageDefinitionBuilder {
         builder.withTask("lambdaTrafficUpdateTask", LambdaTrafficUpdateTask.class);
         builder.withTask("lambdaTrafficUpdateVerificationTask", LambdaTrafficUpdateVerificationTask.class);
         builder.withTask("lambdaPutConcurrencyTask", LambdaPutConcurrencyTask.class);
+        builder.withTask("lambdaDeleteConcurrencyTask", LambdaDeleteConcurrencyTask.class);
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);
         builder.withTask("lambdaEventConfigurationTask", LambdaUpdateEventConfigurationTask.class);
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);

--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/upsert/model/LambdaConcurrencyInput.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/upsert/model/LambdaConcurrencyInput.java
@@ -25,5 +25,6 @@ import lombok.Data;
 public class LambdaConcurrencyInput {
     private String account, appName, credentials,region ,functionName;
     private String qualifier, aliasName;
-    private int reservedConcurrentExecutions, provisionedConcurrentExecutions;
+    private Integer reservedConcurrentExecutions;
+    private Integer provisionedConcurrentExecutions;
 }

--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/utils/LambdaCloudDriverResponse.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/utils/LambdaCloudDriverResponse.java
@@ -19,8 +19,6 @@ package com.amazon.aws.spinnaker.plugin.lambda.utils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Builder;
 import lombok.Data;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Data
 @Builder

--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/utils/LambdaStageConstants.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/utils/LambdaStageConstants.java
@@ -33,6 +33,7 @@ public class LambdaStageConstants {
     public static final String updateEventUrlKey = "updateEventUrl";
     public static final String publishVersionUrlKey = "publishVersionUrl";
     public static final String putConcurrencyUrlKey = "lambdaPutConcurrencyUrl";
+    public static final String deleteConcurrencyUrlKey = "lambdaDeleteConcurrencyUrl";
     public static final String eventTaskKey = "eventConfigUrlList";
     public static final String aliasTaskKey = "updateAliasesUrlList";
     public static final String lambdaObjectKey = "lambdaObject";
@@ -46,5 +47,5 @@ public class LambdaStageConstants {
     public static final String functionNameKey = "functionName";
     public static final String urlKey = "url";
 
-    public static List<String> allUrlKeys = List.of(createdUrlKey, updateCodeUrlKey, updateConfigUrlKey, updateEventUrlKey, publishVersionUrlKey, putConcurrencyUrlKey);
+    public static List<String> allUrlKeys = List.of(createdUrlKey, updateCodeUrlKey, updateConfigUrlKey, updateEventUrlKey, publishVersionUrlKey, putConcurrencyUrlKey, deleteConcurrencyUrlKey);
 }

--- a/lambda-deployment-orca/src/test/java/com/amazon/aws/spinnaker/plugin/lambda/upsert/LambdaDeleteConcurrencyTaskTest.java
+++ b/lambda-deployment-orca/src/test/java/com/amazon/aws/spinnaker/plugin/lambda/upsert/LambdaDeleteConcurrencyTaskTest.java
@@ -1,0 +1,109 @@
+package com.amazon.aws.spinnaker.plugin.lambda.upsert;
+
+import com.amazon.aws.spinnaker.plugin.lambda.upsert.model.LambdaConcurrencyInput;
+import com.amazon.aws.spinnaker.plugin.lambda.utils.LambdaCloudDriverResponse;
+import com.amazon.aws.spinnaker.plugin.lambda.utils.LambdaCloudDriverUtils;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.config.CloudDriverConfigurationProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+import ru.lanwen.wiremock.ext.WiremockUriResolver;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith({WiremockResolver.class, WiremockUriResolver.class})
+public class LambdaDeleteConcurrencyTaskTest {
+
+    WireMockServer wireMockServer;
+
+    @InjectMocks
+    private LambdaDeleteConcurrencyTask lambdaDeleteConcurrencyTask;
+
+    @Mock
+    private CloudDriverConfigurationProperties propsMock;
+
+    @Mock
+    private LambdaCloudDriverUtils lambdaCloudDriverUtilsMock;
+
+    @Mock
+    private StageExecution stageExecution;
+
+    @Mock
+    private PipelineExecution pipelineExecution;
+
+    @BeforeEach
+    void init(@WiremockResolver.Wiremock WireMockServer wireMockServer, @WiremockUriResolver.WiremockUri String uri) {
+        this.wireMockServer = wireMockServer;
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(propsMock.getCloudDriverBaseUrl()).thenReturn(uri);
+        pipelineExecution.setApplication("lambdaApp");
+        Mockito.when(stageExecution.getExecution()).thenReturn(pipelineExecution);
+        Mockito.when(stageExecution.getContext()).thenReturn(new HashMap<String, Object>());
+        Mockito.when(stageExecution.getOutputs()).thenReturn(new HashMap<String, Object>());
+        LambdaConcurrencyInput ldi = LambdaConcurrencyInput.builder()
+                .functionName("functionName")
+                .build();
+        Mockito.when(lambdaCloudDriverUtilsMock.validateUpsertLambdaInput(Mockito.any(), Mockito.anyList() )).thenReturn(true);
+        Mockito.when(lambdaCloudDriverUtilsMock.getInput(stageExecution, LambdaConcurrencyInput.class)).thenReturn(ldi);
+    }
+
+    @Test
+    public void execute_DeleteReservedConcurrency_SUCCEEDED(){
+        Mockito.when(stageExecution.getType()).thenReturn("Aws.LambdaDeploymentStage");
+        LambdaCloudDriverResponse lambdaCloudDriverResponse = LambdaCloudDriverResponse.builder()
+                .resourceUri("/resourceUri")
+                .build();
+        Mockito.when(lambdaCloudDriverUtilsMock
+                .postToCloudDriver(Mockito.any(), Mockito.any())).thenReturn(lambdaCloudDriverResponse);
+        assertEquals(ExecutionStatus.SUCCEEDED, lambdaDeleteConcurrencyTask.execute(stageExecution).getStatus());
+    }
+
+    @Test
+    public void execute_DeleteReservedConcurrency_NOTHING_TO_DELETE(){
+        LambdaConcurrencyInput ldi = LambdaConcurrencyInput.builder()
+                .functionName("functionName")
+                .reservedConcurrentExecutions(10)
+                .build();
+        Mockito.when(lambdaCloudDriverUtilsMock.getInput(stageExecution, LambdaConcurrencyInput.class)).thenReturn(ldi);
+
+        Mockito.when(stageExecution.getType()).thenReturn("Aws.LambdaDeploymentStage");
+        assertEquals(ExecutionStatus.SUCCEEDED, lambdaDeleteConcurrencyTask.execute(stageExecution).getStatus());
+        assertEquals("Lambda delete concurrency : nothing to delete", stageExecution.getOutputs().get("LambdaDeleteConcurrencyTask"));
+    }
+
+    @Test
+    public void execute_DeleteProvisionedConcurrency_SUCCEEDED(){
+        Mockito.when(stageExecution.getType()).thenReturn("Aws.LambdaTrafficRoutingStage");
+        LambdaCloudDriverResponse lambdaCloudDriverResponse = LambdaCloudDriverResponse.builder()
+                .resourceUri("/resourceUri")
+                .build();
+        Mockito.when(lambdaCloudDriverUtilsMock
+                .postToCloudDriver(Mockito.any(), Mockito.any())).thenReturn(lambdaCloudDriverResponse);
+        assertEquals(ExecutionStatus.SUCCEEDED, lambdaDeleteConcurrencyTask.execute(stageExecution).getStatus());
+    }
+
+    @Test
+    public void execute_DeleteProvisionedConcurrency_NOTHING_TO_DELETE(){
+        LambdaConcurrencyInput ldi = LambdaConcurrencyInput.builder()
+                .functionName("functionName")
+                .provisionedConcurrentExecutions(10)
+                .build();
+        Mockito.when(lambdaCloudDriverUtilsMock.getInput(stageExecution, LambdaConcurrencyInput.class)).thenReturn(ldi);
+
+        Mockito.when(stageExecution.getType()).thenReturn("Aws.LambdaTrafficRoutingStage");
+        assertEquals(ExecutionStatus.SUCCEEDED, lambdaDeleteConcurrencyTask.execute(stageExecution).getStatus());
+        assertEquals("Lambda delete concurrency : nothing to delete", stageExecution.getOutputs().get("LambdaDeleteConcurrencyTask"));
+    }
+
+}


### PR DESCRIPTION
This PR is to add a feature for the plugin - we are adding the possibility to delete both Provisioned and Reserved Concurrencies in deploying and routing Aws.lambda stages.
I also cleaned two classes deleting unused imports

This updates on clouddriver are on this PR: [clouddriver-pr](https://github.com/spinnaker/clouddriver/pull/5743)