### PR TITLE
feat(aws.routingStage): Fix order of executing tasks first update or …

### DIFF
--- a/lambda-deployment-deck/src/routeLambda/RouteLambdaFunctionStageForm.tsx
+++ b/lambda-deployment-deck/src/routeLambda/RouteLambdaFunctionStageForm.tsx
@@ -139,7 +139,7 @@ export function RouteLambdaFunctionStageForm(props: IFormikStageConfigInjectedPr
         name="provisionedConcurrentExecutions"
         label="Provisioned Concurrency"
         help={<HelpField content="To enable your function to scale without fluctuations in latency, use provisioned concurrency. Provisioned concurrency runs continually and has separate pricing for concurrency and execution duration. Concurrency cannot be provisioned with a weighted deployment strategy." />}
-        input={props => <NumberConcurrencyInput {...props} min={0} max={values.deploymentStrategy === "$WEIGHTED" ? 0 : 3000} />}
+        input={props => <NumberConcurrencyInput {...props} min={0} max={3000} />}
         required={false}
       />
       

--- a/lambda-deployment-orca/lambda-deployment-orca.gradle
+++ b/lambda-deployment-orca/lambda-deployment-orca.gradle
@@ -8,8 +8,8 @@ apply plugin: "io.spinnaker.plugin.service-extension"
 apply plugin: "maven-publish"
 apply plugin: "java"
 
-sourceCompatibility = 1.11
-targetCompatibility = 1.11
+sourceCompatibility = 11
+targetCompatibility = 11
 
 repositories {
   mavenCentral()
@@ -28,7 +28,6 @@ dependencies {
   compileOnly (group: 'com.netflix.spinnaker.orca', name: 'orca-api', version: "${orcaVersion}")
   compileOnly (group: 'com.netflix.spinnaker.orca', name: 'orca-clouddriver', version: "${orcaVersion}")
   compileOnly (group: 'com.netflix.spinnaker.orca', name: 'orca-core', version: "${orcaVersion}")
-  compileOnly ("org.projectlombok:lombok:1.18.12")
   compileOnly (group: 'com.netflix.spinnaker.kork', name: 'kork-artifacts', version: "${korkVersion}")
   compileOnly (group: 'com.netflix.spinnaker.kork', name: 'kork-plugins-spring-api', version: "${korkVersion}")
   implementation("com.amazonaws:aws-java-sdk:1.11.877")
@@ -40,10 +39,11 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp:4.2.2")
   implementation("com.squareup.okhttp3:okhttp-apache:3.13.1")
   annotationProcessor("org.pf4j:pf4j:3.2.0")
-  annotationProcessor ("org.projectlombok:lombok:1.18.12")
   testImplementation (group: 'com.netflix.spinnaker.orca', name: 'orca-api', version: "${orcaVersion}")
+  testImplementation (group: 'com.netflix.spinnaker.orca', name: 'orca-api-tck', version: "${orcaVersion}")
+  testImplementation (group: 'com.netflix.spinnaker.orca', name: 'orca-queue', version: "${orcaVersion}")
+  testImplementation (group: 'com.netflix.spinnaker.kork', name: 'kork-plugins-tck', version: "${korkVersion}")
 
-  testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.2"
   testImplementation group: 'io.strikt', name: 'strikt-core', version: '0.22.1'
   testImplementation group: 'dev.minutest', name: 'minutest', version: '1.10.0'
   testImplementation group: 'io.mockk', name: 'mockk', version: '1.9.3'
@@ -53,9 +53,29 @@ dependencies {
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '2.19.0'
   testCompile (group: 'com.netflix.spinnaker.orca', name: 'orca-clouddriver', version: "${orcaVersion}")
 
-  testRuntime "org.junit.jupiter:junit-jupiter-engine:5.4.0"
-  testRuntime "org.junit.platform:junit-platform-launcher:1.4.0"
-  testRuntime "org.junit.platform:junit-platform-commons:1.5.2"
+  compileOnly ("org.projectlombok:lombok:1.18.12")
+  annotationProcessor ("org.projectlombok:lombok:1.18.12")
+  testCompile ("org.projectlombok:lombok:1.18.12")
+  testAnnotationProcessor("org.projectlombok:lombok:1.18.12")
+
+  testImplementation("com.fasterxml.jackson.core:jackson-core") {
+    version {
+      strictly '2.11.2'
+    }
+  }
+  testImplementation("com.fasterxml.jackson.core:jackson-annotations") {
+    version {
+      strictly '2.11.2'
+    }
+  }
+  testImplementation("com.fasterxml.jackson.core:jackson-databind") {
+    version {
+      strictly '2.11.2'
+    }
+  }
+
+  testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
+  testImplementation("org.junit.platform:junit-platform-commons:1.4.0")
 }
 
 tasks.withType(Test) {

--- a/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/traffic/LambdaTrafficRoutingStage.java
+++ b/lambda-deployment-orca/src/main/java/com/amazon/aws/spinnaker/plugin/lambda/traffic/LambdaTrafficRoutingStage.java
@@ -42,10 +42,10 @@ public class LambdaTrafficRoutingStage implements StageDefinitionBuilder {
     @Override
     public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
         logger.debug("taskGraph for Aws.LambdaTrafficRoutingStage");
-        builder.withTask("lambdaTrafficUpdateTask", LambdaTrafficUpdateTask.class);
-        builder.withTask("lambdaTrafficUpdateVerificationTask", LambdaTrafficUpdateVerificationTask.class);
         builder.withTask("lambdaPutConcurrencyTask", LambdaPutConcurrencyTask.class);
         builder.withTask("lambdaDeleteConcurrencyTask", LambdaDeleteConcurrencyTask.class);
+        builder.withTask("lambdaTrafficUpdateTask", LambdaTrafficUpdateTask.class);
+        builder.withTask("lambdaTrafficUpdateVerificationTask", LambdaTrafficUpdateVerificationTask.class);
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);
         builder.withTask("lambdaEventConfigurationTask", LambdaUpdateEventConfigurationTask.class);
         builder.withTask("lambdaVerificationTask", LambdaVerificationTask.class);

--- a/lambda-deployment-orca/src/test/java/com/amazon/aws/spinnaker/plugin/lambda/traffic/LambdaTrafficRoutingIntegrationTest.java
+++ b/lambda-deployment-orca/src/test/java/com/amazon/aws/spinnaker/plugin/lambda/traffic/LambdaTrafficRoutingIntegrationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Armory, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.spinnaker.plugin.lambda.traffic;
+
+import com.amazon.aws.spinnaker.plugin.lambda.traffic.model.LambdaTrafficUpdateInput;
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LambdaTrafficRoutingIntegrationTest extends OrcaPluginsFixture {
+
+    @Test
+    public void resolveToCorrectTypeTest() {
+        StageDefinitionBuilder stageDefinitionBuilder = this.stageResolver.getStageDefinitionBuilder(
+            LambdaTrafficRoutingStage.class.getSimpleName(), "Aws.LambdaTrafficRoutingStage");
+
+        assertTrue(stageDefinitionBuilder.aliases().contains("Aws.LambdaTrafficRoutingStage"), "Expected stageDefinitionBuilder to contain Aws.LambdaTrafficRoutingStage");
+        assertEquals(stageDefinitionBuilder.getType(), "lambdaTrafficRouting" , "Expected stageDefinitionBuilder to be of type lambdaTrafficRouting");
+    }
+
+    @Test
+    public void LambdaTrafficRoutingStageIntegrationTest() throws Exception {
+        String content = mapper.writeValueAsString(Map.of(
+                "application","lambda"
+                ,"stages", List.of(Map.of(
+                        "refId","1",
+                        "type","Aws.LambdaTrafficRoutingStage",
+                        "functionName","lambda-myLambda",
+                        "region", "us-west-2",
+                        "deploymentStrategy", "$BLUEGREEN",
+                        "timeout", 30,
+                        "aliasName", "alias1",
+                        "account", "aws-account"
+                ))));
+        final MvcResult postResults = this.mockMvc.perform(MockMvcRequestBuilders
+                .post("/orchestrate")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
+        MockHttpServletResponse response = postResults.getResponse();
+        assertEquals(response.getStatus(), 200);
+
+        Map map = mapper.readValue(response.getContentAsString(), Map.class);
+        final MvcResult getResults = mockMvc.perform(MockMvcRequestBuilders
+                .get((String) map.get("ref")))
+                .andReturn();
+
+        Execution execution = mapper.readValue(getResults.getResponse().getContentAsString(), Execution.class);
+        LambdaTrafficUpdateInput context = execution.getStages().get(0).getContext();
+        assertEquals("lambda-myLambda", context.getFunctionName());
+        assertEquals("us-west-2", context.getRegion());
+        assertEquals("$BLUEGREEN", context.getDeploymentStrategy());
+        assertEquals(30, context.getTimeout());
+        assertEquals("alias1", context.getAliasName());
+        assertEquals("aws-account", context.getAccount());
+    }
+
+}
+    @Data
+    class Execution {
+        String status;
+        List<Stage> stages;
+    }
+
+    @Data
+    class Stage {
+        String status;
+        LambdaTrafficUpdateInput context;
+        String type;
+    }

--- a/lambda-deployment-orca/src/test/java/com/amazon/aws/spinnaker/plugin/lambda/traffic/OrcaPluginsFixture.java
+++ b/lambda-deployment-orca/src/test/java/com/amazon/aws/spinnaker/plugin/lambda/traffic/OrcaPluginsFixture.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Armory, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.spinnaker.plugin.lambda.traffic;
+
+import com.amazon.aws.spinnaker.plugin.lambda.LambdaSpringLoaderPlugin;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.plugins.internal.PluginJar;
+import com.netflix.spinnaker.orca.StageResolver;
+import com.netflix.spinnaker.orca.api.test.OrcaFixture;
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.File;
+
+@TestPropertySource(properties = {
+        "spinnaker.extensibility.plugins.Aws.LambdaDeploymentPlugin.enabled=true",
+        "spinnaker.extensibility.plugins-root-path=build/plugins"
+})
+@AutoConfigureMockMvc
+public class OrcaPluginsFixture extends OrcaFixture {
+    @Autowired
+    StageResolver stageResolver;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    ObjectMapper mapper =  new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    OrcaPluginsFixture() {
+        String pluginId = "Aws.LambdaDeploymentPlugin";
+        File plugins = new File("build/plugins");
+        FileUtils.deleteQuietly(plugins);
+        plugins.mkdir();
+
+        new PluginJar.Builder(plugins.toPath()
+                .resolve(pluginId+".jar"), pluginId)
+                .pluginClass(LambdaSpringLoaderPlugin.class.getName())
+                .pluginVersion("1.0.0")
+                .build();
+    }
+}


### PR DESCRIPTION
There is an issue where you can’t  update provisioned concurrency when deploying a new lamba version and doing a routingStage to move the weights of the alias to the newly deployed version.
<img width="1170" alt="Screen Shot 2022-07-08 at 1 09 34 PM" src="https://user-images.githubusercontent.com/43676929/178055620-4bc10d75-e32f-4ea8-92b6-9080131aae72.png">

The issue is occurring because routing the weights takes some time to complete and while the weights are distributed between two versions requesting to update provisioned concurrency is prevented by AWS.

The aws console suggest to update provisioned before routing.
<img width="1093" alt="Screen Shot 2022-07-08 at 1 08 19 PM" src="https://user-images.githubusercontent.com/43676929/178055479-ea22cac4-b943-429c-9d4e-fefeec578097.png">
